### PR TITLE
Revise rewriteRules string to fix example

### DIFF
--- a/docs/options/index.html
+++ b/docs/options/index.html
@@ -608,7 +608,7 @@ rewriteRules: [
     {
         match: <span class="hljs-regexp">/BrowserSync/g</span>,
         fn: <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(match)</span> </span>{
-            <span class="hljs-keyword">return</span> <span class="hljs-string">"shane"</span>;
+            <span class="hljs-keyword">return</span> <span class="hljs-string">"kittenz"</span>;
         }
     }
 ]</code></pre>


### PR DESCRIPTION
The string should read "kittenz" to reflect the comment guidance.