### PR TITLE
Fix 'codeSync' example in docs.

### DIFF
--- a/_src/_includes/snippets/options/codeSync.js
+++ b/_src/_includes/snippets/options/codeSync.js
@@ -1,2 +1,2 @@
 // Don't send any file-change events to browsers
-codeSync: true,
+codeSync: false

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -77,6 +77,7 @@
                             <li><a href="#api-emitter">.emitter</a></li>
                             <li><a href="#api-active">.active</a></li>
                             <li><a href="#api-paused">.paused</a></li>
+                            <li><a href="#api-sockets">.sockets</a></li>
                     </ul>
                 </div>
 
@@ -496,6 +497,18 @@ bs.init(config, <span class="hljs-function"><span class="hljs-keyword">function<
                 </h3>
 
                 <p><p>A simple true/false flag to determine if the current instance is paused</p>
+                </p>
+
+
+
+
+
+                <h3 id="api-sockets" class="section-link">
+                    <a href="#api-sockets" class="page-anchor">.sockets</a>
+                    <a href="#page-top" class="back-to-top">^ TOP</a>
+                </h3>
+
+                <p><p>Access to client-side socket for emitting events</p>
                 </p>
 
 

--- a/docs/options/index.html
+++ b/docs/options/index.html
@@ -88,6 +88,7 @@
                         <li><a href="#option-notify">notify</a></li>
                         <li><a href="#option-scrollProportionally">scrollProportionally</a></li>
                         <li><a href="#option-scrollThrottle">scrollThrottle</a></li>
+                        <li><a href="#option-scrollRestoreTechnique">scrollRestoreTechnique</a></li>
                         <li><a href="#option-reloadDelay">reloadDelay</a></li>
                         <li><a href="#option-reloadDebounce">reloadDebounce</a></li>
                         <li><a href="#option-plugins">plugins</a></li>
@@ -565,6 +566,7 @@ logSnippet: <span class="hljs-literal">false</span></code></pre>
                 <ul class="param-list">
                     <li class="type">Type: <span class="color-teal">Object</span>
                     <ul class="nav nav--stacked subprops">
+                            <li><b>async</b> - Default: <span class="color-teal">undefined</span></li>
                             <li><b>blacklist</b> - Default: <span class="color-teal">undefined</span></li>
                             <li><b>whitelist</b> - Default: <span class="color-teal">undefined</span></li>
                             <li><b>rule.match</b> - Default: <span class="color-teal">/&lt;body[^&gt;]*&gt;/i</span></li>
@@ -575,7 +577,7 @@ logSnippet: <span class="hljs-literal">false</span></code></pre>
 
                 <p class="lede warning"><b>Note: </b> requires at least version 2.0.0</p>
 
-                <p>SINCE 1.7.0! You can control how the snippet is injected
+                <p>You can control how the snippet is injected
                 onto each page via a custom regex + function.
                 You can also provide patterns for certain urls
                 that should be ignored from the snippet injection.</p>
@@ -823,6 +825,23 @@ notify: <span class="hljs-literal">false</span></code></pre>
 
 
 <pre class='highlight'><code class="js">scrollThrottle: <span class="hljs-number">100</span> <span class="hljs-comment">// only send scroll events every 100 milliseconds</span></code></pre>
+
+
+<h3 id="option-scrollRestoreTechnique" class="section-link">
+    <a href="#option-scrollRestoreTechnique" class="page-anchor">scrollRestoreTechnique</a>
+    <a href="#page-top" class="back-to-top">^ TOP</a>
+</h3>
+
+
+<ul class="param-list">
+    <li class="type">Type: <span class="color-teal">String</span>
+    </li>
+    <li class="default">Default: <span class="color-teal">&#x27;window.name&#x27;</span></li>
+</ul>
+
+
+
+
 
 
 <h3 id="option-reloadDelay" class="section-link">

--- a/docs/options/index.html
+++ b/docs/options/index.html
@@ -105,7 +105,7 @@
             </div>
             <div class="grid__cell three-quarters">
                 <h1 class="page-title">Browsersync options</h1>
-                
+
 
                 <p>These are all the options that you can configure when using Browsersync. Create a single object and pass
                 it as the <a href="/docs/api/#api-browserSync">first argument</a> (for GulpJS and normal API usage). If you&#39;re using Grunt, you can
@@ -999,7 +999,7 @@ host: <span class="hljs-string">"192.168.1.1"</span></code></pre>
 
 
 <pre class='highlight'><code class="js"><span class="hljs-comment">// Don't send any file-change events to browsers</span>
-codeSync: <span class="hljs-literal">true</span>,</code></pre>
+codeSync: <span class="hljs-literal">false</span></code></pre>
 
 
                 <h3 id="option-timestamps" class="section-link">

--- a/docs/options/index.html
+++ b/docs/options/index.html
@@ -105,7 +105,7 @@
             </div>
             <div class="grid__cell three-quarters">
                 <h1 class="page-title">Browsersync options</h1>
-
+                
 
                 <p>These are all the options that you can configure when using Browsersync. Create a single object and pass
                 it as the <a href="/docs/api/#api-browserSync">first argument</a> (for GulpJS and normal API usage). If you&#39;re using Grunt, you can
@@ -999,7 +999,7 @@ host: <span class="hljs-string">"192.168.1.1"</span></code></pre>
 
 
 <pre class='highlight'><code class="js"><span class="hljs-comment">// Don't send any file-change events to browsers</span>
-codeSync: <span class="hljs-literal">false</span></code></pre>
+codeSync: <span class="hljs-literal">true</span>,</code></pre>
 
 
                 <h3 id="option-timestamps" class="section-link">

--- a/docs/options/index.html
+++ b/docs/options/index.html
@@ -1018,7 +1018,8 @@ host: <span class="hljs-string">"192.168.1.1"</span></code></pre>
 
 
 <pre class='highlight'><code class="js"><span class="hljs-comment">// Don't send any file-change events to browsers</span>
-codeSync: <span class="hljs-literal">true</span>,</code></pre>
+codeSync: <span class="hljs-literal">false</span>
+</code></pre>
 
 
                 <h3 id="option-timestamps" class="section-link">


### PR DESCRIPTION
Switched from 'true' to 'false', also removed extra comma.
