### PR TITLE
Suggested updates to 'Browsersync + Gulp' documentation

### DIFF
--- a/_src/_includes/snippets/gulp/reload.js
+++ b/_src/_includes/snippets/gulp/reload.js
@@ -14,7 +14,7 @@ gulp.task('js', function () {
 gulp.task('js-watch', ['js'], browserSync.reload);
 
 // use default task to launch Browsersync and watch JS files
-gulp.task('serve', ['js'], function () {
+gulp.task('serve', ['js'], function (async) {
 
     // Serve files from the root of this project
     browserSync.init({

--- a/_src/_includes/snippets/gulp/reload.manual.js
+++ b/_src/_includes/snippets/gulp/reload.manual.js
@@ -5,7 +5,7 @@ var reload      = browserSync.reload;
 // Save a reference to the `reload` method
 
 // Watch scss AND html files, doing different things with each.
-gulp.task('serve', function () {
+gulp.task('serve', function (async) {
 
     // Serve files from the root of this project
     browserSync.init({

--- a/_src/_includes/snippets/gulp/require.js
+++ b/_src/_includes/snippets/gulp/require.js
@@ -2,7 +2,7 @@ var gulp        = require('gulp');
 var browserSync = require('browser-sync').create();
 
 // Static server
-gulp.task('browser-sync', function() {
+gulp.task('browser-sync', function(async) { // async support
     browserSync.init({
         server: {
             baseDir: "./"
@@ -12,7 +12,7 @@ gulp.task('browser-sync', function() {
 
 // or...
 
-gulp.task('browser-sync', function() {
+gulp.task('browser-sync', function(async) { // async support
     browserSync.init({
         proxy: "yourlocal.dev"
     });

--- a/_src/_includes/snippets/gulp/sass.js
+++ b/_src/_includes/snippets/gulp/sass.js
@@ -3,7 +3,7 @@ var browserSync = require('browser-sync').create();
 var sass        = require('gulp-sass');
 
 // Static Server + watching scss/html files
-gulp.task('serve', ['sass'], function() {
+gulp.task('serve', ['sass'], function(async) {
 
     browserSync.init({
         server: "./app"

--- a/_src/_includes/snippets/gulp/sass.maps.js
+++ b/_src/_includes/snippets/gulp/sass.maps.js
@@ -3,7 +3,7 @@ var sass        = require("gulp-ruby-sass");
 var browserSync = require("browser-sync").create();
 
 // Static Server + watching scss/html files
-gulp.task('serve', ['sass'], function() {
+gulp.task('serve', ['sass'], function(async) {
 
     browserSync.init({
         server: "./app"

--- a/_src/docs/gulp.hbs
+++ b/_src/docs/gulp.hbs
@@ -27,8 +27,10 @@ Then, use them within your `gulpfile.js`:
 
 {{ hl src="snippets/gulp/require.js" }}
 
+{{#md}}
 Be sure to pass a callback to the task to ensure it [supports async](https://github.com/gulpjs/gulp/blob/master/docs/API.md#async-task-support)
 so that the `browserSync` [server](/docs/options/#option-server) stays running.
+{{/md}}
 
 {{ inc src="headerlink.html" title="SASS + CSS Injecting" slug="gulp-sass-css" }}
 

--- a/_src/docs/gulp.hbs
+++ b/_src/docs/gulp.hbs
@@ -27,6 +27,9 @@ Then, use them within your `gulpfile.js`:
 
 {{ hl src="snippets/gulp/require.js" }}
 
+Be sure to pass a callback to the task to ensure it [supports async](https://github.com/gulpjs/gulp/blob/master/docs/API.md#async-task-support)
+so that the `browserSync` [server](/docs/options/#option-server) stays running.
+
 {{ inc src="headerlink.html" title="SASS + CSS Injecting" slug="gulp-sass-css" }}
 
 {{#md}}


### PR DESCRIPTION
The documentation is potentially misleading. `Gulp` [dictates](https://github.com/gulpjs/gulp/blob/master/docs/API.md#async-task-support) that a task must do one of the following:
1. accept a callback
2. return a stream
3. return a promise

...in order for the task to behave asynchronously.

I found myself spending far more time than desired debugging an issue that could have been solved if I had just a little bit more knowledge.

The suggestion is to make a few minor updates to the documentation, to save the heartache for future consumers that I had to experience.

The changes in this pull request are as follows:
- For all tasks that don't return streams, supply a callback.
- Add an inline comment to the code block(s) for the _very first_ example.
- Add a sentence explaining the necessity for ensuring the task is asynchronous, after the _very first_ example.
