### PR TITLE
Fixed typo in the API doc

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -162,7 +162,7 @@ bs.reload(<span class="hljs-string">"*.html"</span>);
 
 
 <div class="highlight-block"><div class="highlight-header"><span class="circle"></span><span class="circle"></span><span class="circle"></span><svg class="svg-icon "><use xlink:href="/img/icons/icons.svg#svg-code"></use></svg></div><pre class='highlight'><code class="js"><span class="hljs-comment">// Create an named instance in one file...</span>
-<span class="hljs-keyword">var</span> bs = <span class="hljs-built_in">require</span>(<span class="hljs-string">"browser-sync"</span>).create(<span class="hljs-string">'My Server'</span>);
+<span class="hljs-keyword">var</span> bs = <span class="hljs-built_in">require</span>(<span class="hljs-string">"browser-sync"</span>).create(<span class="hljs-string">'My server'</span>);
 
 <span class="hljs-comment">// Start the Browsersync server</span>
 bs.init({


### PR DESCRIPTION
The instance was created with the name "My Server" instead of "My server".