### PR TITLE
Update reload.js

### DIFF
--- a/_src/_includes/snippets/gulp/reload.js
+++ b/_src/_includes/snippets/gulp/reload.js
@@ -17,7 +17,7 @@ gulp.task('js-watch', ['js'], function (done) {
 });
 
 // use default task to launch Browsersync and watch JS files
-gulp.task('serve', ['js'], function () {
+gulp.task('default', ['js'], function () {
 
     // Serve files from the root of this project
     browserSync.init({


### PR DESCRIPTION
Comment in line 19 says: "use default task to launch Browsersync and watch JS files". 
Use 'default' task, not 'serve' task.