### PR TITLE
Fixed punctuation

### DIFF
--- a/_src/docs/gulp.hbs
+++ b/_src/docs/gulp.hbs
@@ -53,8 +53,8 @@ To fix this problem, use `browserSync.stream({match: '**/*.css'})` as seen in th
 
 {{#md}}
 Sometimes you might just want to reload the page completely (for example, after processing a bunch of JS files), but
-you want the reload to happen *after* your tasks. This will be easier in gulp `4.x.x`, but for now you can do the following:
-(make sure you `return` the stream from your tasks to ensure that `browserSync.reload()` is called at the correct time.
+you want the reload to happen *after* your tasks. This will be easier in gulp `4.x.x`, but for now you can do the following
+(make sure you `return` the stream from your tasks to ensure that `browserSync.reload()` is called at the correct time):
 {{/md}}
 
 {{ hl src="snippets/gulp/reload.js" }}


### PR DESCRIPTION
In Browsersync + Gulp documentation, a parenthesis is not closed. This PR fixes this, and also makes it belong to the previous sentence.