### PR TITLE
Correct default setting for `open`

### DIFF
--- a/doc/yuidoc.json
+++ b/doc/yuidoc.json
@@ -554,7 +554,7 @@
         "itemtype": "property",
         "name": "open",
         "type": "Boolean|String",
-        "default": "true",
+        "default": "local",
         "class": "",
         "module": "BrowserSync.options"
     }, {


### PR DESCRIPTION
Defaults to `local` for documentation and `browser-sync init` however main default is incorrectly stated as `true`.

![capture d ecran 2017-07-09 a 00 17 12](https://user-images.githubusercontent.com/38223/27991160-2a88a5be-643c-11e7-9d39-655a25f4986d.png)
