### PR TITLE
Fix link to download page for node.js

### DIFF
--- a/_src/_includes/home/install.hbs
+++ b/_src/_includes/home/install.hbs
@@ -6,7 +6,7 @@
         <ol class="step-list">
             <li class="step">
                 <h3>1. Install Node.js</h3>
-                <p>Browsersync is a module for Node.js, a platform for fast network applications. There are convenient <a href="http://nodejs.org/download/">installers for MacOS, Windows and Linux</a>.</p>
+                <p>Browsersync is a module for Node.js, a platform for fast network applications. There are convenient <a href="https://nodejs.org/en/download/">installers for MacOS, Windows and Linux</a>.</p>
             </li>
             <li class="step">
                 <h3>2. Install Browsersync</h3>


### PR DESCRIPTION
Changes node.js link to https://nodejs.org/en/download/