### PR TITLE
Correct Capitalisation of npm

### DIFF
--- a/_src/_includes/install.hbs
+++ b/_src/_includes/install.hbs
@@ -28,7 +28,7 @@ $ npm install browser-sync --save-dev
 {{/hl}}
 
 **WARNING - do not use sudo!** If you're running `Mac OSX` and encounter problems when trying to install Browsersync - either
-globally or locally, it's almost always because you have problems with NPM permissions. Checkout [their docs]({{site.links.npmdocs}})
+globally or locally, it's almost always because you have problems with npm permissions. Checkout [their docs]({{site.links.npmdocs}})
 for a guide on how to fix this once and for all - it only takes 2 minutes :)
 
 {{inc src="headerlink" title="Requirements" slug="requirements"}}


### PR DESCRIPTION
The kind people at npm really hate it when you capitalise their product's name.

https://www.npmjs.com/about