### PR TITLE
Improving routes docs for server

### DIFF
--- a/_src/_includes/snippets/options/server.js
+++ b/_src/_includes/snippets/options/server.js
@@ -31,7 +31,7 @@ server: {
 }
 
 // Since version 1.2.1
-// The key is the url to match
+// The key is the url to match (can't match any existing file yet)
 // The value is which folder to serve (relative to your current working directory)
 server: {
     baseDir: "app",


### PR DESCRIPTION
I wanted to route all requests for files in /dir to /dir2 but it didn't work until I figured out that routes only work if the key/url doesn't match any existing file. I added a little hint for this behaviour.