### PR TITLE
Fix broken link to gulpjs docs on browsersync.io/docs/gulp#gulp-reload

### DIFF
--- a/_src/docs/gulp.hbs
+++ b/_src/docs/gulp.hbs
@@ -56,7 +56,7 @@ Sometimes you might just want to reload the page completely (for example, after 
 you want the reload to happen *after* your tasks. This will be easier in gulp `4.x.x`, but for now you can do the following
 (make sure you `return` the stream from your tasks to ensure that `browserSync.reload()` is called at the correct time).
 
-If you are using gulp `4.x.x` now, then you can [follow this documentation](https://github.com/gulpjs/gulp/blob/4.0/docs/recipes/minimal-browsersync-setup-with-gulp4.md).
+If you are using gulp `4.x.x` now, then you can [follow this documentation](https://github.com/gulpjs/gulp/blob/master/docs/recipes/minimal-browsersync-setup-with-gulp4.md).
 {{/md}}
 
 {{ hl src="snippets/gulp/reload.js" }}


### PR DESCRIPTION
This fixes a broken "follow this documentation" link under the [Browser Reloading](https://browsersync.io/docs/gulp#gulp-reload) section of the Browsersync + Gulp.js documentation.